### PR TITLE
Fixes for compatability with Gutenberg 2.3.0

### DIFF
--- a/src/EditBlock.js
+++ b/src/EditBlock.js
@@ -103,7 +103,7 @@ class EditBlock extends Component {
 
 				// Display the shortcode preview (if it's been fetched properly).
 				(
-					<div className="wp-block-shortcake-preview" key="preview" style={ focus && { minHeight: this.state.minHeight } }>
+					<div className="wp-block-shortcake-preview" key="preview" style={ focus ? { minHeight: this.state.minHeight } : {} }>
 						<SandBox html={ preview } title={ `${label} shortcode preview` } type={ shortcode_tag } />
 						<div className={ "wp-block-shortcake-preview-overlay" + ( focus ? ' editing' : '' ) }
 							onClick={ setFocus }
@@ -128,7 +128,7 @@ class EditBlock extends Component {
 
 				// Or the preformatted shortcode text if no preview is available.
 				(
-					<div className="wp-block-shortcake-preview" key="content" style={ focus && { minHeight: this.state.minHeight } }>
+					<div className="wp-block-shortcake-preview" key="content" style={ focus ? { minHeight: this.state.minHeight } : {} }>
 						<code
 							onFocus={ setFocus }
 							onBlur={ this.maybeUpdatePreview }

--- a/src/EditBlock.js
+++ b/src/EditBlock.js
@@ -2,6 +2,7 @@
 import React from 'react';
 
 import Fetcher from './utils/Fetcher';
+import Sandbox from './utils/Sandbox';
 import ShortcodeEditForm from './ShortcodeEditForm';
 
 import './EditBlock.css'
@@ -83,8 +84,6 @@ class EditBlock extends Component {
 	}
 
 	render() {
-		const { SandBox } = wp.components;
-
 		const { attrs, label, shortcode_tag } = this.shortcode;
 		const { attributes: values, setAttributes, focus, setFocus } = this.props;
 		const { content, preview } = this.state;
@@ -104,7 +103,7 @@ class EditBlock extends Component {
 				// Display the shortcode preview (if it's been fetched properly).
 				(
 					<div className="wp-block-shortcake-preview" key="preview" style={ focus ? { minHeight: this.state.minHeight } : {} }>
-						<SandBox html={ preview } title={ `${label} shortcode preview` } type={ shortcode_tag } />
+						<Sandbox html={ preview } title={ `${label} shortcode preview` } type={ shortcode_tag } />
 						<div className={ "wp-block-shortcake-preview-overlay" + ( focus ? ' editing' : '' ) }
 							onClick={ setFocus }
 							onFocus={ setFocus }

--- a/src/registerShortcodeBlock.js
+++ b/src/registerShortcodeBlock.js
@@ -5,6 +5,7 @@ import mapItemImage from './utils/mapItemImage';
 import EditBlock from './EditBlock';
 
 const { registerBlockType } = wp.blocks;
+const { RawHTML } = wp.element;
 
 /**
  * Register a Gutenberg block for a shortcode with UI.
@@ -47,7 +48,7 @@ const registerShortcodeBlock = function( shortcode ) {
 			edit: EditBlock.bind( null, shortcode ),
 
 			save( { attributes } ) {
-				return wp.shortcode.string( { tag: shortcode_tag, attrs: attributes } );
+				return RawHTML( { children: [ wp.shortcode.string( { tag: shortcode_tag, attrs: attributes } ) ] } );
 			}
 		}
 	);

--- a/src/utils/Sandbox.js
+++ b/src/utils/Sandbox.js
@@ -1,0 +1,27 @@
+/* global wp: false */
+
+import React from 'react';
+
+const { SandBox } = wp.components;
+
+/**
+ * Extends the wp.component.Sandbox class to include all the same logic, except for the "sandbox" attributes on the iframe.
+ *
+ * Fixes errors like `Uncaught DOMException: Failed to set the 'domain'
+ * property on 'Document': Assignment is forbidden for sandboxed iframes.`
+ */
+class Sandbox extends SandBox {
+	render() {
+		return (
+			<iframe
+				ref={ ( node ) => this.iframe = node }
+				title={ this.props.title }
+				scrolling="no"
+				onLoad={ this.trySandbox }
+				width={ Math.ceil( this.state.width ) }
+				height={ Math.ceil( this.state.height ) } />
+		);
+	}
+}
+
+export default Sandbox;


### PR DESCRIPTION
Adapts to a couple areas where the Gutenberg API has changed:

* Entends the built-in "SandBox" component used for shortcode previews to not output a "sandbox" attribute on the iframe used to hold the preview, because that causes errors when embedding previews from domains with content security policies - and just because it's not necessary for the previews we're rendering, which aren't supposed to be interactive in any way.

* Fix the way we return style attribute values to avoid throwing JSX warnings when the calculated style of an element evaluates to something other than an object (in some places, "style" was a boolean false value.)

* Use the `wp.element.RawHTML()` method to build blocks' `save()` output, rather than just returning a string which was throwing a deprecation warning.